### PR TITLE
API Root changed

### DIFF
--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1,3 +1,3 @@
-const API_URL = process.env.SOS_API_URL || 'http://localhost:8000/'
+const API_URL = process.env.SOS_API_URL || 'http://localhost:8000/api/'
 
 export { API_URL }


### PR DESCRIPTION
The API is now rooted at /api instead of /

This is a breaking change, but, no one is using this. At least they shouldn't be...